### PR TITLE
Upgrade `yfinance` package in quarto-stock-report-python

### DIFF
--- a/bundles/quarto-stock-report-python/requirements.txt
+++ b/bundles/quarto-stock-report-python/requirements.txt
@@ -6,6 +6,6 @@ nbconvert==7.16.5
 ipykernel==6.29.3
 ipywidgets==8.1.2
 
-matplotlib
-pandas
-yfinance==0.2.37
+matplotlib==3.10.1
+pandas==2.2.3
+yfinance==0.2.54


### PR DESCRIPTION
- Upgrade `yfinance` to 0.2.54 for hotfix
  - Fixes error where ticker couldn't be found
- Pin `matplotlib` and `pandas`